### PR TITLE
added missing option go_package

### DIFF
--- a/chapter-C.31-golang-grpc-protobuf/common/model/garage.proto
+++ b/chapter-C.31-golang-grpc-protobuf/common/model/garage.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package model;
+option go_package = "./common/model";
 
 message GarageCoordinate {
     float latitude = 1;

--- a/chapter-C.31-golang-grpc-protobuf/common/model/user.proto
+++ b/chapter-C.31-golang-grpc-protobuf/common/model/user.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package model;
+option go_package = "./common/model";
 
 enum UserGender {
     UNDEFINED = 0;


### PR DESCRIPTION
https://developers.google.com/protocol-buffers/docs/reference/go-generated#package

> In order to generate Go code, the Go package's import path must be provided for every .proto file (including those transitively depended upon by the .proto files being generated).