### PR TITLE
refactor: Fix deprecated `io/ioutil`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# IDE
+.idea
+.vscode

--- a/chapter-A.62-concurrency-pipeline/1-dummy-file-generator.go
+++ b/chapter-A.62-concurrency-pipeline/1-dummy-file-generator.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -44,7 +43,7 @@ func generateFiles() {
 	for i := 0; i < totalFile; i++ {
 		filename := filepath.Join(tempPath, fmt.Sprintf("file-%d.txt", i))
 		content := randomString(contentLength)
-		err := ioutil.WriteFile(filename, []byte(content), os.ModePerm)
+		err := os.WriteFile(filename, []byte(content), os.ModePerm)
 		if err != nil {
 			log.Println("Error writing file", filename)
 		}

--- a/chapter-A.62-concurrency-pipeline/2-find-md5-sum-of-file-then-rename-it.go
+++ b/chapter-A.62-concurrency-pipeline/2-find-md5-sum-of-file-then-rename-it.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/md5"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ func proceed() {
 		counterTotal++
 
 		// read file
-		buf, err := ioutil.ReadFile(path)
+		buf, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/chapter-A.62-concurrency-pipeline/3-find-md5-sum-of-file-then-rename-it-concurrently.go
+++ b/chapter-A.62-concurrency-pipeline/3-find-md5-sum-of-file-then-rename-it-concurrently.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/md5"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -72,7 +71,7 @@ func readFiles() <-chan FileInfo {
 				return nil
 			}
 
-			buf, err := ioutil.ReadFile(path)
+			buf, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/chapter-A.63-simplified-fan-in-fan-out-pipeline/1-generate-dummy-files-sequentially.go
+++ b/chapter-A.63-simplified-fan-in-fan-out-pipeline/1-generate-dummy-files-sequentially.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -44,7 +43,7 @@ func generateFiles() {
 	for i := 0; i < totalFile; i++ {
 		filename := filepath.Join(tempPath, fmt.Sprintf("file-%d.txt", i))
 		content := randomString(contentLength)
-		err := ioutil.WriteFile(filename, []byte(content), os.ModePerm)
+		err := os.WriteFile(filename, []byte(content), os.ModePerm)
 		if err != nil {
 			log.Println("Error writing file", filename)
 		}

--- a/chapter-A.63-simplified-fan-in-fan-out-pipeline/2-generate-dummy-files-concurrently.go
+++ b/chapter-A.63-simplified-fan-in-fan-out-pipeline/2-generate-dummy-files-concurrently.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -99,7 +98,7 @@ func createFiles(chanIn <-chan FileInfo, numberOfWorkers int) <-chan FileInfo {
 				for job := range chanIn {
 					filePath := filepath.Join(tempPath, job.FileName)
 					content := randomString(contentLength)
-					err := ioutil.WriteFile(filePath, []byte(content), os.ModePerm)
+					err := os.WriteFile(filePath, []byte(content), os.ModePerm)
 
 					log.Println("worker", workerIndex, "working on", job.FileName, "file generation")
 

--- a/chapter-A.64-pipeline-context-cancellation/1-generate-file-concurrently.go
+++ b/chapter-A.64-pipeline-context-cancellation/1-generate-file-concurrently.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -99,7 +98,7 @@ func createFiles(chanIn <-chan FileInfo, numberOfWorkers int) <-chan FileInfo {
 				for job := range chanIn {
 					filePath := filepath.Join(tempPath, job.FileName)
 					content := randomString(contentLength)
-					err := ioutil.WriteFile(filePath, []byte(content), os.ModePerm)
+					err := os.WriteFile(filePath, []byte(content), os.ModePerm)
 
 					log.Println("worker", workerIndex, "working on", job.FileName, "file generation")
 

--- a/chapter-A.64-pipeline-context-cancellation/2-generate-file-cancellable.go
+++ b/chapter-A.64-pipeline-context-cancellation/2-generate-file-cancellable.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -131,7 +130,7 @@ func createFiles(ctx context.Context, chanIn <-chan FileInfo, numberOfWorkers in
 					default:
 						filePath := filepath.Join(tempPath, job.FileName)
 						content := randomString(contentLength)
-						err := ioutil.WriteFile(filePath, []byte(content), os.ModePerm)
+						err := os.WriteFile(filePath, []byte(content), os.ModePerm)
 
 						log.Println("worker", workerIndex, "working on", job.FileName, "file generation")
 

--- a/chapter-B.22-simple-configuration/conf/config.go
+++ b/chapter-B.22-simple-configuration/conf/config.go
@@ -2,7 +2,6 @@ package conf
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -33,7 +32,7 @@ func init() {
 		return
 	}
 
-	bts, err := ioutil.ReadFile(filepath.Join(basePath, "conf", "config.json"))
+	bts, err := os.ReadFile(filepath.Join(basePath, "conf", "config.json"))
 	if err != nil {
 		panic(err)
 		return

--- a/chapter-B.23-server-handler-http-request-cancellation/2-handle-cancelled-request-with-payload.go
+++ b/chapter-B.23-server-handler-http-request-cancellation/2-handle-cancelled-request-with-payload.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -14,7 +14,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 		// do the process here
 		// simulate a long-time request by putting 10 seconds sleep
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		_ = err
 		_ = body
 

--- a/chapter-C.27-secure-insecure-client-http-request/client-secure-request.go
+++ b/chapter-C.27-secure-insecure-client-http-request/client-secure-request.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 )
 
 type M map[string]interface{}
@@ -28,7 +28,7 @@ func doRequest(url, method string, data interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	certFile, err := ioutil.ReadFile("server.crt")
+	certFile, err := os.ReadFile("server.crt")
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func main() {
 //  log.Fatalln("Unable to load cert", err)
 // }
 
-// clientCACert, err := ioutil.ReadFile("server.crt")
+// clientCACert, err := os.ReadFile("server.crt")
 // if err != nil {
 //  log.Fatal("Unable to open cert", err)
 // }

--- a/chapter-C.28-golang-ftp/main.go
+++ b/chapter-C.28-golang-ftp/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/jlaffaye/ftp"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -87,7 +86,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	test1ContentInBytes, err := ioutil.ReadAll(fileTest1)
+	test1ContentInBytes, err := io.ReadAll(fileTest1)
 	fileTest1.Close()
 	if err != nil {
 		log.Fatal(err.Error())
@@ -101,7 +100,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	test2ContentInBytes, err := ioutil.ReadAll(fileTest2)
+	test2ContentInBytes, err := io.ReadAll(fileTest2)
 	fileTest2.Close()
 	if err != nil {
 		log.Fatal(err.Error())

--- a/chapter-C.29-golang-ssh-sftp/1-simple.go
+++ b/chapter-C.29-golang-ssh-sftp/1-simple.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"golang.org/x/crypto/ssh"
-	"io/ioutil"
 	"log"
 	"os"
 )
 
 func PublicKeyFile(file string) ssh.AuthMethod {
-	buffer, err := ioutil.ReadFile(file)
+	buffer, err := os.ReadFile(file)
 	if err != nil {
 		return nil
 	}

--- a/chapter-C.29-golang-ssh-sftp/2-multiple-commands.go
+++ b/chapter-C.29-golang-ssh-sftp/2-multiple-commands.go
@@ -3,15 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
 )
 
 func PublicKeyFile(file string) ssh.AuthMethod {
-	buffer, err := ioutil.ReadFile(file)
+	buffer, err := os.ReadFile(file)
 	if err != nil {
 		return nil
 	}

--- a/chapter-C.29-golang-ssh-sftp/3-sftp.go
+++ b/chapter-C.29-golang-ssh-sftp/3-sftp.go
@@ -4,13 +4,12 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 )
 
 func PublicKeyFile(file string) ssh.AuthMethod {
-	buffer, err := ioutil.ReadFile(file)
+	buffer, err := os.ReadFile(file)
 	if err != nil {
 		return nil
 	}

--- a/chapter-C.30-golang-protobuf-implementation/go.mod
+++ b/chapter-C.30-golang-protobuf-implementation/go.mod
@@ -1,3 +1,5 @@
 module chapter-c29
 
+go 1.21.3
+
 require github.com/golang/protobuf v1.3.2

--- a/chapter-C.31-golang-grpc-protobuf/go.mod
+++ b/chapter-C.31-golang-grpc-protobuf/go.mod
@@ -1,38 +1,74 @@
 module chapter-c30
 
+go 1.21.3
+
+require (
+	github.com/golang/protobuf v1.3.2
+	google.golang.org/grpc v1.26.0
+)
+
 require (
 	cloud.google.com/go v0.50.0 // indirect
 	cloud.google.com/go/bigquery v1.3.0 // indirect
+	cloud.google.com/go/datastore v1.0.0 // indirect
 	cloud.google.com/go/pubsub v1.1.0 // indirect
 	cloud.google.com/go/storage v1.4.0 // indirect
 	dmitri.shuralyov.com/gpu/mtl v0.0.0-20191203043605-d42048ed14fd // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/client9/misspell v0.3.4 // indirect
 	github.com/creack/pty v1.1.9 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/go-control-plane v0.9.1 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 // indirect
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
-	github.com/golang/protobuf v1.3.2
+	github.com/golang/mock v1.3.1 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/martian v2.1.0+incompatible // indirect
 	github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc // indirect
+	github.com/google/renameio v0.1.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kr/pty v1.1.8 // indirect
+	github.com/kr/text v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.1.0 // indirect
 	github.com/rogpeppe/go-internal v1.5.1 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.4.0 // indirect
 	go.opencensus.io v0.22.2 // indirect
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect
 	golang.org/x/exp v0.0.0-20191227195350-da58074b4299 // indirect
 	golang.org/x/image v0.0.0-20191214001246-9130b4cfad52 // indirect
+	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/mobile v0.0.0-20191210151939-1a1fef82734d // indirect
+	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191224085550-c709ea063b76 // indirect
+	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/api v0.15.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191223191004-3caeed10a8bf // indirect
-	google.golang.org/grpc v1.26.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/errgo.v2 v2.1.0 // indirect
 	gopkg.in/yaml.v2 v2.2.7 // indirect
+	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
+	rsc.io/binaryregexp v0.2.0 // indirect
 )

--- a/chapter-C.32-golang-jwt/main.go
+++ b/chapter-C.32-golang-jwt/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -96,7 +95,7 @@ func HandlerLogin(w http.ResponseWriter, r *http.Request) {
 func authenticateUser(username, password string) (bool, M) {
 	basePath, _ := os.Getwd()
 	dbPath := filepath.Join(basePath, "users.json")
-	buf, _ := ioutil.ReadFile(dbPath)
+	buf, _ := os.ReadFile(dbPath)
 
 	data := make([]M, 0)
 	err := json.Unmarshal(buf, &data)

--- a/chapter-C.33-ldap-authentication/go.mod
+++ b/chapter-C.33-ldap-authentication/go.mod
@@ -1,6 +1,10 @@
 module chapter-c33
 
+go 1.21.3
+
+require github.com/go-ldap/ldap v0.0.0-20191214221535-a4f79d8a7cda
+
 require (
-	github.com/go-ldap/ldap v0.0.0-20191214221535-a4f79d8a7cda
+	github.com/go-asn1-ber/asn1-ber v1.3.1 // indirect
 	github.com/go-ldap/ldap/v3 v3.1.5 // indirect
 )

--- a/chapter-D.2-google-api-search/2-request-cancellation/main.go
+++ b/chapter-D.2-google-api-search/2-request-cancellation/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -105,7 +105,7 @@ func doSearch(
 
 		if resp != nil {
 			defer resp.Body.Close()
-			resData, err := ioutil.ReadAll(resp.Body)
+			resData, err := io.ReadAll(resp.Body)
 			if err != nil {
 				innerChanErr <- err
 				return

--- a/chapter-D.3-golang-web-socket-chatting-app/main.go
+++ b/chapter-D.3-golang-web-socket-chatting-app/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -36,7 +35,7 @@ type WebSocketConnection struct {
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		content, err := ioutil.ReadFile("index.html")
+		content, err := os.ReadFile("index.html")
 		if err != nil {
 			http.Error(w, "Could not open requested file", http.StatusInternalServerError)
 			return

--- a/in progress/chapter-D.4-golang-webrtc-video-conference/main.go
+++ b/in progress/chapter-D.4-golang-webrtc-video-conference/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -17,7 +17,7 @@ var connectionsMap sync.Map
 
 func main() {
 	http.HandleFunc("/chat", func(w http.ResponseWriter, r *http.Request) {
-		buf, err := ioutil.ReadFile("index.html")
+		buf, err := os.ReadFile("index.html")
 		if err != nil {
 			http.Error(w, "Could not serve html file", http.StatusBadRequest)
 			return


### PR DESCRIPTION
# Description

change `ioutil.WriteFile` to `os.WriteFile`,
 `ioutil.ReadFile` to `os.ReadFile`,
 `ioutil.ReadAll` to `io.ReadAll`)

Please see https://github.com/go-critic/go-critic/issues/1019