### PR TITLE
refactor: Fix deprecated gorilla/websocket change websocket.upgrade() to upgrader.upgrade()

### DIFF
--- a/chapter-D.3-golang-web-socket-chatting-app/go.mod
+++ b/chapter-D.3-golang-web-socket-chatting-app/go.mod
@@ -3,6 +3,6 @@ module chapter-D.3
 go 1.20
 
 require (
-	github.com/gorilla/websocket v1.4.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/novalagung/gubrak/v2 v2.0.0
 )

--- a/chapter-D.3-golang-web-socket-chatting-app/go.sum
+++ b/chapter-D.3-golang-web-socket-chatting-app/go.sum
@@ -2,8 +2,8 @@ github.com/DefinitelyMod/gocsv v0.0.0-20181205141819-acfa5f112b45 h1:+OD9vawobD8
 github.com/DefinitelyMod/gocsv v0.0.0-20181205141819-acfa5f112b45/go.mod h1:+nlrAh0au59iC1KN5RA1h1NdiOQYlNOBrbtE1Plqht4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/novalagung/gubrak/v2 v2.0.0 h1:7wqp2XA2cLuTHyxVYw3AS+vRSfiwo8h3hmKxPFulOmA=
 github.com/novalagung/gubrak/v2 v2.0.0/go.mod h1:zilliNLzP2RSdZ67Sz7NdqI4bg3j5zUTFR34tuXopA0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/chapter-D.3-golang-web-socket-chatting-app/main.go
+++ b/chapter-D.3-golang-web-socket-chatting-app/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gorilla/websocket"
@@ -17,6 +18,11 @@ const MESSAGE_CHAT = "Chat"
 const MESSAGE_LEAVE = "Leave"
 
 var connections = make([]*WebSocketConnection, 0)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
 
 type SocketPayload struct {
 	Message string
@@ -45,7 +51,7 @@ func main() {
 	})
 
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		currentGorillaConn, err := websocket.Upgrade(w, r, w.Header(), 1024, 1024)
+		currentGorillaConn, err := upgrader.Upgrade(w, r, w.Header())
 		if err != nil {
 			http.Error(w, "Could not open websocket connection", http.StatusBadRequest)
 		}


### PR DESCRIPTION
Change `websocket.upgrade()` to `upgrader.upgrade()` on `main.go` [Line 48](https://github.com/novalagung/dasarpemrogramangolang-example/blob/b460b751eab0d168870710e1fcbbc6f9fee9c183/chapter-D.3-golang-web-socket-chatting-app/main.go#L48)

Based on https://pkg.go.dev/github.com/gorilla/websocket@v1.5.3#Upgrade and [Documentation](https://pkg.go.dev/github.com/gorilla/websocket@v1.5.3#section-documentation)