### PR TITLE
refactor: remove parameter in Add() method

### DIFF
--- a/chapter-A.60-mutex/1-race-condition.go
+++ b/chapter-A.60-mutex/1-race-condition.go
@@ -10,7 +10,7 @@ type counter struct {
 	val int
 }
 
-func (c *counter) Add(x int) {
+func (c *counter) Add() {
 	c.val++
 }
 
@@ -29,7 +29,7 @@ func main() {
 
 		go func() {
 			for j := 0; j < 1000; j++ {
-				meter.Add(1)
+				meter.Add()
 			}
 
 			wg.Done()


### PR DESCRIPTION
remove `x int` parameter in Add() method. It is unnecessary since the passed value wouldn't be used, it will always increment the value `c.val` by one.